### PR TITLE
Reduce interpolatable values to 5 types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+dist: xenial
+language: minimal
+  # Use `nvm` to install latest version of NodeJS
+
+# Unless we specify "sudo: false", build runs in VM, not container
+
+# Limit the number of commits it will clone
+git:
+  depth: 3
+
+# Only do CI for the default branch
+branches:
+  only:
+  - master
+
+before_install:
+  - nvm install node
+  # ^ Install latest version of Node
+  - npm i -g npm
+  # ^ Update NPM
+
+install:
+  - npm i -g purescript@0.13.5 pulp bower
+  - bower i
+
+script:
+  - pulp test
+
+cache:
+  directories:
+    - bower_components

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest release](http://img.shields.io/github/release/jordanmartinez/purescript-interpolate.svg)](https://github.com/jordanmartinez/purescript-interpolate/releases)
 [![Build Status](https://travis-ci.org/jordanmartinez/purescript-interpolate.svg?branch=master)](https://travis-ci.org/jordanmartinez/purescript-interpolate)
 
-Enables string interpolation for PureScript by rendering values using their `Show` typeclass instance. Credit goes to @natefaubion for original implementation.
+Enables string interpolation for PureScript for values of 5 different types: `String`, `Boolean`, `Int`, `Number`, and `Char`. Credit goes to @natefaubion for original implementation. This project is a modified version of that implementation.
 
 ```purescript
 i "there are " 52 "apples." == "there are 52 apples"

--- a/src/Data/Interpolate.purs
+++ b/src/Data/Interpolate.purs
@@ -10,13 +10,27 @@
 -- | in
 -- |   i "There are " variableName " apples."
 -- | ```
+-- |
+-- | **Note:** string interpolation only works for the following types:
+-- | - String
+-- | - Boolean
+-- | - Int
+-- | - Number
+-- | - Char
+-- |
+-- | This restriction is intentional for two reasons:
+-- | 1. It avoids "instance wars" since orphan instances are not allowed in PureScript.
+-- | 2. It avoids unexpected `String` outputs when dealing with newtypes.
 module Data.Interpolate where
 
-import Data.Show (class Show, show)
 import Data.Semigroup ((<>))
+import Data.Show (show)
+import Partial.Unsafe (unsafeCrashWith)
+import Prim.TypeError (class Fail, Text)
 
--- | Enables string interpolation by rendering values using their Show
--- | typeclass instance.
+-- | Enables string interpolation on values for only the following types:
+-- | `String`, `Boolean`, `Int`, `Number`, and `Char`. Values for all other
+-- | types will need to be converted into one of the above types first.
 -- |
 -- | **Note:** Use the derived function `i` rather than `Interp`'s `interp`
 -- | function as the latter requires the first argument to be a `String`
@@ -26,6 +40,11 @@ import Data.Semigroup ((<>))
 -- | ```
 -- | i "there are " 52 "apples." == "there are 52 apples"
 -- | i 52 " apples and " 0 " oranges." == "52 apples and 0 oranges."
+-- |
+-- | -- `Maybe Int` must be converted into an `Int` before interpolation works.
+-- | let example1 maybeInt = i (fromMaybe 0 maybeInt) " apples."
+-- | example1 Nothing == "0 apples."
+-- | example1 (Just 4) == "4 apples."
 -- | ```
 class Interp a where
   -- | Use the derived function, `i`, instead of this function to do
@@ -42,17 +61,42 @@ class Interp a where
 
 instance interpString :: Interp String where
   interp a = a
-else instance interpFunction :: Interp a => Interp (String -> a) where
+else instance interpStringFunction :: Interp a => Interp (String -> a) where
   interp a b = interp (a <> b)
-else instance interpShow :: (Show b, Interp a) => Interp (b -> a) where
+else instance interpBooleanFunction :: Interp a => Interp (Boolean -> a) where
   interp a b = interp (a <> show b)
+else instance interpIntFunction :: Interp a => Interp (Int -> a) where
+  interp a b = interp (a <> show b)
+else instance interpNumberFunction :: Interp a => Interp (Number -> a) where
+  interp a b = interp (a <> show b)
+else instance interpCharFunction :: Interp a => Interp (Char -> a) where
+  interp a b = interp (a <> show b)
+-- | String interpolation only works for the following types:
+-- | - String
+-- | - Boolean
+-- | - Int
+-- | - Number
+-- | - Char
+-- |
+-- | This restriction is intentional for two reasons:
+-- | 1. It avoids "instance wars" since orphan instances are not allowed in PureScript.
+-- | 2. It avoids unexpected `String` outputs when dealing with newtypes.
+else instance interpFailEverythingElse :: Fail (
+  Text "String interpolation only works on the following primitive values: \
+       \`String`, `Boolean`, `Int`, `Number`, and `Char`. Moreover, using \
+       \newtypes to get around this will fail. These restrictions are \
+       \intentional. Please use a function to render your type's value into \
+       \a value of one of these types before it gets passed as an argument \
+       \into the `i` function."
+  ) => Interp anythingElse where
+  interp a = unsafeCrashWith "A compiler error will prevent this from running."
 
 -- | Enables string interpolation using the following syntax:
 -- |
 -- | ```
 -- | i "there are " 52 "apples." == "there are 52 apples"
 -- | i 52 " apples and " 0 " oranges." == "52 apples and 0 oranges."
--- | i true 4 42.0 'c' "string" [1] [2,3] == "true442.0'c'string[1][2,3]"
+-- | i true 4 42.0 'c' "string" == "true442.0'c'string"
 -- | ```
 i :: forall a. Interp a => a
 i = interp ""

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -23,7 +23,9 @@ main = launchAff_ $ runSpec [consoleReporter] do
       i 'a' 'b' 'c' `shouldEqual` "'a''b''c'"
     it "Interpolating strings works" do
       i "a" "b" "c" `shouldEqual` "abc"
-    it "Interpolating arrays works" do
-      i [1] [2] [3, 4] `shouldEqual` "[1][2][3,4]"
     it "Interpolating values with different types works" do
       i 0 1.0 true 'a' "a" `shouldEqual` "01.0true'a'a"
+
+    -- Intentional: this will fail to compile
+    -- it "Interpolating values from unaccepted types will produce a compiler error" do
+    --   i [1, 2, 3] `shouldEqual` "[1, 2, 3]"


### PR DESCRIPTION
Fixes #2 

This reduces the interpolateable values to the following 5 types:
- String
- Boolean
- Int
- Number
- Char

All but `String` reuse the type's `Show` instance.

I've also tried to overcommunicate throughout the documentation so that one understands how to use the code no matter where they look first.

Moreover, there is another instance in the chain that matches all other types, so that one gets a better compiler error that instructs them how to proceed. 

Anyone who tries to use a newtype to make another type interpolateable by using the below pattern will get an "orphan instance" compiler error because of the instance chain being used:
```purescript
newtype Age = Age Int
instance interpAge :: Interp a => Interp (Age -> a) where
 interp a (Age age) = interp (a <> show age <> " age")
```