### PR TITLE
Use unsafeCrashWith from purescript-partial 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/jordanmartinez/purescript-interpolate.git"
   },
   "dependencies": {
-    "purescript-prelude": "^6.0.0"
+    "purescript-prelude": "^6.0.0",
+    "purescript-partial": "^4.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^6.0.0",

--- a/src/Data/Interpolate.js
+++ b/src/Data/Interpolate.js
@@ -1,3 +1,0 @@
-export const unsafeCrashWith = function(msg) {
-  throw new Error(msg);
-}

--- a/src/Data/Interpolate.purs
+++ b/src/Data/Interpolate.purs
@@ -25,6 +25,7 @@ module Data.Interpolate (class Interp, interp, i) where
 
 import Data.Semigroup ((<>))
 import Data.Show (show)
+import Partial.Unsafe (unsafeCrashWith)
 import Prim.TypeError (class Fail, Text)
 
 -- | Enables string interpolation on values for only the following types:
@@ -99,5 +100,3 @@ else instance interpFailEverythingElse :: Fail (
 -- | ```
 i :: forall a. Interp a => a
 i = interp ""
-
-foreign import unsafeCrashWith :: forall a. String -> a


### PR DESCRIPTION
Fixes #6.

Removed src/Data/Interpolate.js entirely (thereby making the library more portable to other compiler target languages?) and replaces it with a dependency on purescript-partial. 